### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 MCP Terminal 是一个基于 MCP（Model Context Protocol）的终端控制服务器，专为与大型语言模型（LLM）和 AI 助手集成而设计。它提供了一个标准化的接口，使 AI 可以执行终端命令并获取输出结果。
 
+<a href="https://glama.ai/mcp/servers/@sichang824/mcp-terminal">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sichang824/mcp-terminal/badge" alt="Terminal MCP server" />
+</a>
+
 [English](README.en.md) | 中文
 
 </div>


### PR DESCRIPTION
This PR adds a badge for the [MCP Terminal](https://glama.ai/mcp/servers/@sichang824/mcp-terminal) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sichang824/mcp-terminal">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sichang824/mcp-terminal/badge" alt="Terminal MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.